### PR TITLE
Add tab export document

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ TabbyTab is a Chrome extension for efficient tab management with history trackin
 - Tab history tracking with grouping by time, window, domain, or title
 - Search functionality for both active tabs and history
 - Expand/collapse tab groups
+- Export grouped tabs to a shareable document
 
 ## Technical Stack
 - Preact for UI components (3KB alternative to React)

--- a/manifest.json
+++ b/manifest.json
@@ -28,7 +28,7 @@
   ],
   "web_accessible_resources": [
     {
-      "resources": ["src/popup/*", "src/history/*", "src/styles/*"],
+      "resources": ["src/popup/*", "src/history/*", "src/export/*", "src/styles/*"],
       "matches": ["<all_urls>"]
     }
   ]

--- a/src/components/ProtectedPatterns.tsx
+++ b/src/components/ProtectedPatterns.tsx
@@ -50,7 +50,7 @@ export function ProtectedPatterns() {
       const updatedPatterns = [...patterns, newPatternObj];
       savePatterns(updatedPatterns);
       setNewPattern('');
-    } catch (error) {
+    } catch {
       setError('Invalid regular expression');
     }
   };

--- a/src/export/ExportView.tsx
+++ b/src/export/ExportView.tsx
@@ -1,0 +1,88 @@
+import { useEffect, useState } from 'preact/hooks';
+import { ExportDocument } from '../types';
+
+export function ExportView() {
+  const [html, setHtml] = useState('');
+  const [docId, setDocId] = useState('');
+
+  useEffect(() => {
+    const load = async () => {
+      const urlParams = new URLSearchParams(window.location.search);
+      const id = urlParams.get('docId');
+      if (id) {
+        setDocId(id);
+        const { exportDocs = [] } = await chrome.storage.local.get('exportDocs');
+        const doc: ExportDocument | undefined = exportDocs.find((d: ExportDocument) => d.id === id);
+        if (doc) {
+          setHtml(doc.html);
+        }
+      } else {
+        const { currentExportDoc = '' } = await chrome.storage.local.get('currentExportDoc');
+        setHtml(currentExportDoc);
+      }
+    };
+    load();
+  }, []);
+
+  const handleLinkClick = async (e: Event) => {
+    const target = e.target as HTMLElement;
+    if (target.tagName !== 'A') return;
+    e.preventDefault();
+    const tabIdStr = target.getAttribute('data-tabid');
+    const href = (target as HTMLAnchorElement).href;
+    if (tabIdStr) {
+      const tabId = parseInt(tabIdStr, 10);
+      try {
+        await chrome.tabs.get(tabId);
+        await chrome.tabs.update(tabId, { active: true });
+      } catch {
+        await chrome.tabs.create({ url: href });
+      }
+    } else {
+      await chrome.tabs.create({ url: href });
+    }
+  };
+
+  const handleSave = async () => {
+    if (!html) return;
+    const id = Date.now().toString();
+    const doc: ExportDocument = { id, html, timestamp: Date.now() };
+    const { exportDocs = [] } = await chrome.storage.local.get('exportDocs');
+    await chrome.storage.local.set({ exportDocs: [...exportDocs, doc] });
+    await chrome.storage.local.set({ currentExportDoc: '' });
+    const exportUrl = chrome.runtime.getURL(`export/index.html?docId=${id}`);
+    // Add to tab history
+    const historyEntry = {
+      id: id,
+      tabInfo: {
+        id: 0,
+        title: 'Tab Export',
+        url: exportUrl,
+        windowId: 0,
+        domain: 'tabbytab-export',
+        active: false,
+      },
+      timestamp: Date.now(),
+      closed: false,
+    };
+    const { tabHistory = [] } = await chrome.storage.local.get('tabHistory');
+    await chrome.storage.local.set({ tabHistory: [historyEntry, ...tabHistory] });
+    setDocId(id);
+    window.location.search = `?docId=${id}`;
+  };
+
+  return (
+    <div className="export-view">
+      <div className="export-actions">
+        {docId === '' && (
+          <button onClick={handleSave} className="control-button">Save Document</button>
+        )}
+      </div>
+      <div
+        className="export-content"
+        onClick={handleLinkClick}
+        dangerouslySetInnerHTML={{ __html: html }}
+      />
+    </div>
+  );
+}

--- a/src/export/index.html
+++ b/src/export/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Tab Export</title>
+  <link rel="stylesheet" href="../styles/main.css">
+</head>
+<body>
+  <div id="app"></div>
+  <script type="module" src="./index.tsx"></script>
+</body>
+</html>

--- a/src/export/index.tsx
+++ b/src/export/index.tsx
@@ -1,0 +1,5 @@
+import { render } from 'preact';
+import { ExportView } from './ExportView';
+import '../styles/main.css';
+
+render(<ExportView />, document.getElementById('app')!);

--- a/src/popup/TabsView.tsx
+++ b/src/popup/TabsView.tsx
@@ -177,9 +177,69 @@ export function TabsView() {
   };
 
   const handleCollapseAll = () => {
-    setGroupedTabs(prevGroups => 
+    setGroupedTabs(prevGroups =>
       prevGroups.map(group => ({ ...group, expanded: false }))
     );
+  };
+
+  const handleExportTabs = async () => {
+    try {
+      const chromeTabs = await chrome.tabs.query({});
+
+      const tabInfos = await Promise.all(
+        chromeTabs.map(async (tab) => {
+          const url = tab.url || '';
+          let domain = '';
+          try {
+            if (url) domain = new URL(url).hostname;
+          } catch { /* ignore */ }
+
+          let ogTitle = '';
+          try {
+            if (tab.id) {
+              const [res] = await chrome.scripting.executeScript({
+                target: { tabId: tab.id },
+                func: () => {
+                  const meta = document.querySelector(
+                    'meta[property="og:title"]'
+                  ) as HTMLMetaElement | null;
+                  return meta ? meta.content : '';
+                },
+              });
+              ogTitle = res.result as string;
+            }
+          } catch { /* ignore */ }
+
+          const title = ogTitle || `${domain} - ${tab.title || 'Untitled'}`;
+
+          return { id: tab.id || 0, url, domain, title };
+        })
+      );
+
+      const groups: Record<string, { id: number; url: string; domain: string; title: string }[]> = {};
+      tabInfos.forEach((info) => {
+        const group = info.domain || 'No Domain';
+        if (!groups[group]) groups[group] = [];
+        groups[group].push(info);
+      });
+
+      const parts: string[] = ['<h1>Open Tabs</h1>'];
+      for (const [group, tabsIn] of Object.entries(groups)) {
+        parts.push(`<h2>${group}</h2><ul>`);
+        tabsIn.forEach((t) => {
+          parts.push(
+            `<li><a href="${t.url}" data-tabid="${t.id}">${t.title}</a></li>`
+          );
+        });
+        parts.push('</ul>');
+      }
+
+      const html = parts.join('');
+      await chrome.storage.local.set({ currentExportDoc: html });
+      chrome.tabs.create({ url: chrome.runtime.getURL('export/index.html') });
+    } catch (error) {
+      console.error('Error exporting tabs:', error);
+    }
   };
 
   // Function to move all domain groups to their own windows
@@ -382,13 +442,19 @@ export function TabsView() {
           </button>
         </div>
         <div className="header-buttons">
-          <button 
+          <button
             className="header-button"
             onClick={() => window.location.href = chrome.runtime.getURL('history/index.html')}
           >
             View History
           </button>
-          <button 
+          <button
+            className="header-button"
+            onClick={handleExportTabs}
+          >
+            Export Tabs
+          </button>
+          <button
             className="settings-button"
             onClick={() => setShowProtectedPatterns(!showProtectedPatterns)}
           >

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -686,3 +686,7 @@ body {
     max-width: 200px;
   }
 }
+.export-actions { margin-bottom: 1rem; }
+.export-content a { color: var(--primary-color); text-decoration: none; }
+.export-content a:hover { text-decoration: underline; }
+

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,3 +36,9 @@ export interface ProtectedPattern {
   pattern: string;
   enabled: boolean;
 }
+
+export interface ExportDocument {
+  id: string;
+  html: string;
+  timestamp: number;
+}


### PR DESCRIPTION
## Summary
- allow export of grouped tabs via new button
- gather OpenGraph titles if present when building export
- display export in new page with link handling
- store saved export docs and add an entry in history
- document export feature in README

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6840a614f3e48330838e1d8e8923a08b